### PR TITLE
feat: working on V1 of no-ternary-wrappers rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 # eslint-plugin-unnecessary-abstractions
 
-This is a simple ESLint plugin which includes rules to help detect the unnecessary use of certain code abstractions.
+This ESLint plugin provides rules to detect and prevent some unnecessary code abstractions.
 ## Rules
 ### no-ternary-wrappers
 
+
+Creating functions to abstract ternaries used only once or twice is considered bad practice. 
+
+Rather than reducing or effectively hiding complexity, this adds unnecessary overhead and can result in less maintainable code.
+
 ```javascript
-// Incorrect ❌
-function isUserRightHanded(rightHanded, rightHand, leftHand) {
-  return rightHanded ? rightHand : leftHand; // Don't create a function just to wrap a ternary
+// Incorrect: Don't create a function just to wrap a ternary ❌  
+function getMainHand(userIsRightHanded, rightHand, leftHand) {
+  return userIsRightHanded ? rightHand : leftHand;
+  // Unnecessary abstraction:
+  // Use the ternary expression directly
+  // instead of wrapping it in a function.
 }
 
-useHand(isUserRightHanded(isRightHandedUser, user.rightHand, user.leftHand));
+const mainHand = getMainHand(userIsRightHanded, user.rightHand, user.leftHand);
 
-// Correct ✅ 
-useHand(isRightHandedUser ? user.rightHand : user.leftHand); // Use the ternary directly
+------------------------------------
+
+// Correct: Use the ternary directly ✅ 
+const mainHand = userIsRightHanded ? user.rightHand : user.leftHand;
 
 ```
 
 ## Installation
 
-Install it as part of your devDependencies
+Install it as part of your `devDependencies`
 ```sh
 npm i --save-dev eslint-plugin-unnecessary-abstractions
 ```
@@ -31,7 +41,9 @@ Import the plugin and add it as a configuration object to the array of configura
 import unnecessaryAbstractions from "eslint-plugin-unnecessary-abstractions";
 
 export default [
-  // ... other configurations
+  {
+    // ... other configurations
+  },
   {
     plugins: { "unnecessary-abstractions": unnecessaryAbstractions },
     rules: {
@@ -49,11 +61,11 @@ Add `"unnecessary-abstractions"` to the plugins array of your ESLint configurati
 // .eslintrc.js
 
 module.exports = {
-  // Add the plugin to the list
+  // Add the plugin to the plugins array
   plugins: [/* ... */ , "unnecessary-abstractions"],
   rules: {
     // Add the rules you want
-    "unnecessary-abstractions/no-ternary-wrappers": "warn" // or "error
+    "unnecessary-abstractions/no-ternary-wrappers": "warn" // or "error"
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-unnecessary-abstractions",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "This is a simple ESLint plugin which includes rules to help detect the unnecessary use of certain code abstractions.",
   "exports": "./src/index.js",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const noUnnecessaryTernaryWrappers = require("./rules/no-ternary-wrappers.js");
 module.exports = {
   meta: {
     name: "unnecessary-abstractions",
-    version: "0.1.4",
+    version: "1.0.0",
   },
   rules: {
     "no-ternary-wrappers": noUnnecessaryTernaryWrappers,

--- a/src/rules/no-ternary-wrappers.js
+++ b/src/rules/no-ternary-wrappers.js
@@ -1,6 +1,6 @@
 const errorMessages = {
   UNNECESSARY_TERNARY_WRAPPER:
-    "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+    "Unnecessary abstraction: Use the ternary expression directly instead of wrapping it in a function.",
 };
 
 /**

--- a/src/rules/no-ternary-wrappers.js
+++ b/src/rules/no-ternary-wrappers.js
@@ -44,52 +44,12 @@ module.exports = {
       significantOperations: false,
     };
 
-    const functionWithBracketsCheck = (functionNode) => {
+    const arrowOrNormalFunctionCheck = (functionNode) => {
       //If there are significant operations then we dont have to check anything
       if (info.significantOperations) return;
 
-      const bodyElements = functionNode.body.body;
-
-      // If the only child of the function
-      // is a ternary expression, report an error
-      if (
-        bodyElements.length === 1 &&
-        bodyElements[0].type === "ReturnStatement" &&
-        bodyElements[0].argument?.type === "ConditionalExpression"
-      ) {
-        const ternary = bodyElements[0].argument;
-
-        const onlyIdentifiersInTernary = [
-          ternary.test,
-          ternary.consequent,
-          ternary.alternate,
-        ].every((x) => x.type === "Identifier");
-
-        if (!onlyIdentifiersInTernary) return;
-
-        const ternaryFromArguments = [
-          ternary.test.name,
-          ternary.consequent.name,
-          ternary.alternate.name,
-        ].every((identifierName) =>
-          checkIfLocalParam(identifierName, functionNode),
-        );
-        if (ternaryFromArguments) {
-          context.report({
-            node: functionNode,
-            message: errorMessages.UNNECESSARY_TERNARY_WRAPPER,
-          });
-        }
-      }
-    };
-
-    const arrowFunctionCheck = (functionNode) => {
-      //If there are significant operations then we dont have to check anything
-      if (info.significantOperations) return;
-
-      // If the only child of the arrow function
-      // is a ternary expression, report an error
       let ternary;
+
       if (functionNode.body.type === "ConditionalExpression") {
         ternary = functionNode.body;
       }
@@ -143,10 +103,9 @@ module.exports = {
     const checkIfSignificantOperations = () => {};
 
     return {
-      // "BlockStatement:exit": functionWithBracketsCheck,
-      "ArrowFunctionExpression:exit": arrowFunctionCheck,
-      "FunctionExpression:exit": functionWithBracketsCheck,
-      "FunctionDeclaration:exit": functionWithBracketsCheck,
+      "ArrowFunctionExpression:exit": arrowOrNormalFunctionCheck,
+      "FunctionExpression:exit": arrowOrNormalFunctionCheck,
+      "FunctionDeclaration:exit": arrowOrNormalFunctionCheck,
     };
   },
 };

--- a/src/rules/no-ternary-wrappers.js
+++ b/src/rules/no-ternary-wrappers.js
@@ -1,44 +1,3 @@
-const arrowFunctionCheck = (node, context) => {
-  // If the only child of the arrow function
-  // is a ternary expression, report an error
-  if (node.body.type === "ConditionalExpression") {
-    context.report({
-      node,
-      message:
-        "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-    });
-  }
-};
-
-const blockStatementCheck = (node, context) => {
-  const applicableParentTypes = [
-    "FunctionExpression",
-    "ArrowFunctionExpression",
-    "MethodDefinition",
-    "FunctionDeclaration",
-  ];
-
-  // If the node.parent.type isn't one that
-  // interests us, we don't need to do anything
-  if (!applicableParentTypes.includes(node.parent.type)) {
-    return;
-  }
-
-  // If the only child of the function
-  // is a ternary expression, report an error
-  if (
-    node.body.length === 1 &&
-    node.body[0].type === "ReturnStatement" &&
-    node.body[0].argument.type === "ConditionalExpression"
-  ) {
-    context.report({
-      node,
-      message:
-        "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-    });
-  }
-};
-
 module.exports = {
   meta: {
     type: "suggestion",
@@ -49,13 +8,49 @@ module.exports = {
     },
   },
   create(context) {
+    const blockStatementCheck = (node) => {
+      const applicableParentTypes = [
+        "FunctionExpression",
+        "ArrowFunctionExpression",
+        "MethodDefinition",
+        "FunctionDeclaration",
+      ];
+
+      // If the node.parent.type isn't one that
+      // interests us, we don't need to do anything
+      if (!applicableParentTypes.includes(node.parent.type)) {
+        return;
+      }
+
+      // If the only child of the function
+      // is a ternary expression, report an error
+      if (
+        node.body.length === 1 &&
+        node.body[0].type === "ReturnStatement" &&
+        node.body[0].argument.type === "ConditionalExpression"
+      ) {
+        context.report({
+          node,
+          message:
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+        });
+      }
+    };
+
+    const arrowFunctionCheck = (node) => {
+      // If the only child of the arrow function
+      // is a ternary expression, report an error
+      if (node.body.type === "ConditionalExpression") {
+        context.report({
+          node,
+          message:
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+        });
+      }
+    };
     return {
-      BlockStatement(node) {
-        blockStatementCheck(node, context);
-      },
-      ArrowFunctionExpression(node) {
-        arrowFunctionCheck(node, context);
-      },
+      BlockStatement: blockStatementCheck,
+      ArrowFunctionExpression: arrowFunctionCheck,
     };
   },
 };

--- a/src/rules/no-ternary-wrappers.js
+++ b/src/rules/no-ternary-wrappers.js
@@ -1,14 +1,30 @@
+const errorMessages = {
+  UNNECESSARY_TERNARY_WRAPPER:
+    "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+};
+
 module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Point out unnecessary ternary wrappers",
+      description: "Points out unnecessary ternary wrappers",
       category: "Best Practices",
       recommended: true,
     },
   },
   create(context) {
+    // ContextObject
+
+    const info = {
+      significantOperations: false,
+    };
+
     const blockStatementCheck = (node) => {
+      //If there are significant operations then we dont have to check anything
+      if (info.significantOperations) return;
+
+      // If the node.parent.type isn't one that
+      // interests us, we don't need to do anything
       const applicableParentTypes = [
         "FunctionExpression",
         "ArrowFunctionExpression",
@@ -16,8 +32,6 @@ module.exports = {
         "FunctionDeclaration",
       ];
 
-      // If the node.parent.type isn't one that
-      // interests us, we don't need to do anything
       if (!applicableParentTypes.includes(node.parent.type)) {
         return;
       }
@@ -31,26 +45,40 @@ module.exports = {
       ) {
         context.report({
           node,
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+          message: errorMessages.UNNECESSARY_TERNARY_WRAPPER,
         });
       }
     };
 
     const arrowFunctionCheck = (node) => {
+      //If there are significant operations then we dont have to check anything
+      if (info.significantOperations) return;
+
       // If the only child of the arrow function
       // is a ternary expression, report an error
       if (node.body.type === "ConditionalExpression") {
         context.report({
           node,
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+          message: errorMessages.UNNECESSARY_TERNARY_WRAPPER,
         });
       }
     };
+
+    //Yisustodo: use this method to set info.significantOperations
+    //to true if there are significant operations
+    //like mutations or some assignments, side effects, etc
+
+    /**
+     * Checks if there are any significant operations
+     * like assignments, calls, or other transformations
+     * done on the arguments of the ternary
+     * @returns {boolean} whether or not there are any significant operations
+     * */
+    const checkIfSignificantOperations = () => {};
+
     return {
-      BlockStatement: blockStatementCheck,
-      ArrowFunctionExpression: arrowFunctionCheck,
+      "BlockStatement:exit": blockStatementCheck,
+      "ArrowFunctionExpression:exit": arrowFunctionCheck,
     };
   },
 };

--- a/tests/examplefiles/filewitherrors.js
+++ b/tests/examplefiles/filewitherrors.js
@@ -1,10 +1,32 @@
+// Valid
+
+let test, left, right;
+const validByUsingGlobalStuff = () => {
+  return test ? left : right;
+};
+
+function validByUsingLocalStuff(test, left, right) {
+  const sum = left + right;
+  const max = Math.max(left, right);
+
+  return test ? sum : max;
+}
+
 function technicallyValid(a, b, c) {
   console.log(a, b, c);
   return a ? b : c;
 }
 
-const invalid = (a, b, c) => {
+// Invalid
+
+(a, b, c) => (a ? b : c);
+
+const arrowNoBrackets = (a, b, c) => (a ? b : c);
+
+const arrowBrackets = (a, b, c) => {
   return a ? b : c;
 };
 
-const alsoInvalid = (a, b, c) => (a ? b : c);
+function normalFunc(a, b, c) {
+  return a ? b : c;
+}

--- a/tests/no-ternary-wrappers.spec.js
+++ b/tests/no-ternary-wrappers.spec.js
@@ -105,6 +105,22 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
         }
       `,
     },
+    // This should be valid as well since we're not only returning the ternary
+    // but instead we're doing some other stuff
+    // However there should be an option to flag this as a possible error
+    // TODO: Add an option to flag this as a possible error
+    {
+      name: "valid: Some other contrived ternary wrapper",
+      code: `export const someContrivedTernary = (
+                someFirstValue,
+                someEnum,
+                labels
+              )=>
+                typeof _.get(labels, [someFirstValue]) === 'string'
+                  ? _.get(labels, [someFirstValue], labels.default)
+                  : _.get(labels, [someFirstValue, someEnum], labels.default);`,
+      errors: 1,
+    },
   ],
   invalid: [
     // more cases for completion's sake
@@ -240,21 +256,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
     {
       name: "(c)normal function with brackets around the return statement",
       code: `function someFunction(a, b, c) { return c ? b : a}`,
-      errors: 1,
-    },
-    // This should be valid as well since we're not only returning the ternary
-    // but instead we're doing some other stuff
-    // However there should be an option to flag this as a possible error
-    {
-      name: "Some other contrived ternary wrapper",
-      code: `export const someContrivedTernary = (
-                someFirstValue,
-                someEnum,
-                labels
-              )=>
-                typeof _.get(labels, [someFirstValue]) === 'string'
-                  ? _.get(labels, [someFirstValue], labels.default)
-                  : _.get(labels, [someFirstValue, someEnum], labels.default);`,
       errors: 1,
     },
   ],

--- a/tests/no-ternary-wrappers.spec.js
+++ b/tests/no-ternary-wrappers.spec.js
@@ -121,6 +121,58 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
                   : _.get(labels, [someFirstValue, someEnum], labels.default);`,
       errors: 1,
     },
+    // These three functions are valid for now but there should
+    // really be an option to flag this as a possible error,
+    // since no meaningful operations are being done there
+    // TODO: Add an option to flag this as a possible error
+    {
+      code: `
+        function getHandWithLog(rightHanded, rightHand, leftHand) {
+          console.log('Determining hand');
+          return rightHanded ? rightHand : leftHand;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+        },
+      ],
+    },
+
+    // Function with unused variables trying to bypass the rule
+    // TODO: Add an option to flag this as a possible error
+    {
+      code: `
+        function chooseHandWithExtras(rightHanded, rightHand, leftHand) {
+          const extra = 'extra logic';
+          return rightHanded ? rightHand : leftHand;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+        },
+      ],
+    },
+
+    // Function indirectly wrapping a ternary with unnecessary indirection
+    // TODO: Add an option to flag this as a possible error
+    {
+      code: `
+        function getChoice(optionA, optionB, condition) {
+          const result = condition ? optionA : optionB;
+          return result;
+        }
+      `,
+      errors: [
+        {
+          message:
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
+        },
+      ],
+    },
   ],
   invalid: [
     // more cases for completion's sake
@@ -157,53 +209,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       code: `
         function chooseHand(rightHanded, rightHand, leftHand) {
           return rightHanded ? rightHand : leftHand;
-        }
-      `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
-    },
-    // Function with a console log trying to appear meaningful
-    {
-      code: `
-        function getHandWithLog(rightHanded, rightHand, leftHand) {
-          console.log('Determining hand');
-          return rightHanded ? rightHand : leftHand;
-        }
-      `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
-    },
-
-    // Function with unused variables trying to bypass the rule
-    {
-      code: `
-        function chooseHandWithExtras(rightHanded, rightHand, leftHand) {
-          const extra = 'extra logic';
-          return rightHanded ? rightHand : leftHand;
-        }
-      `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
-    },
-
-    // Function indirectly wrapping a ternary with unnecessary indirection
-    {
-      code: `
-        function getChoice(optionA, optionB, condition) {
-          const result = condition ? optionA : optionB;
-          return result;
         }
       `,
       errors: [

--- a/tests/no-ternary-wrappers.spec.js
+++ b/tests/no-ternary-wrappers.spec.js
@@ -119,7 +119,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
                 typeof _.get(labels, [someFirstValue]) === 'string'
                   ? _.get(labels, [someFirstValue], labels.default)
                   : _.get(labels, [someFirstValue, someEnum], labels.default);`,
-      errors: 1,
     },
     // These three functions are valid for now but there should
     // really be an option to flag this as a possible error,
@@ -132,12 +131,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
           return rightHanded ? rightHand : leftHand;
         }
       `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
     },
 
     // Function with unused variables trying to bypass the rule
@@ -149,12 +142,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
           return rightHanded ? rightHand : leftHand;
         }
       `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
     },
 
     // Function indirectly wrapping a ternary with unnecessary indirection
@@ -166,12 +153,6 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
           return result;
         }
       `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
     },
   ],
   invalid: [
@@ -185,23 +166,13 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
           return rightHanded ? rightHand : leftHand;
         }
       `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
+      errors: 1,
     },
 
     // Arrow function wrapping a ternary
     {
       code: `const isUserRightHanded = (rightHanded, rightHand, leftHand) => rightHanded ? rightHand : leftHand;`,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
+      errors: 1,
     },
 
     // Function declaration wrapping a ternary
@@ -211,56 +182,21 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
           return rightHanded ? rightHand : leftHand;
         }
       `,
-      errors: [
-        {
-          message:
-            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
-        },
-      ],
+      errors: 1,
     },
     {
-      name: "(a) Arrow function with brackets around the return statement",
+      name: "Arrow function with brackets around the return statement",
       code: `const someFunction = (a, b, c) => {return a ? b : c};`,
       errors: 1,
     },
     {
-      name: "(a)Arrow function without brackets around the return statement",
+      name: "jarrow function without brackets around the return statement",
       code: `const someFunction = (a, b, c) => a ? b : c;`,
       errors: 1,
     },
     {
-      name: "(a)normal function without brackets around the return statement",
+      name: "normal function with brackets around the return statement",
       code: `function someFunction(a, b, c) { return a ? b : c}`,
-      errors: 1,
-    },
-    {
-      name: "(b) Arrow function with brackets around the return statement",
-      code: `const someFunction = (a, b, c) => {return b ? a : c};`,
-      errors: 1,
-    },
-    {
-      name: "(b)Arrow function without brackets around the return statement",
-      code: `const someFunction = (a, b, c) => b ? a : c;`,
-      errors: 1,
-    },
-    {
-      name: "(b)normal function without brackets around the return statement",
-      code: `function someFunction(a, b, c) { return b ? a : c}`,
-      errors: 1,
-    },
-    {
-      name: "(c) Arrow function with brackets around the return statement",
-      code: `const someFunction = (a, b, c) => {return c ? b : a};`,
-      errors: 1,
-    },
-    {
-      name: "(c)Arrow function without brackets around the return statement",
-      code: `const someFunction = (a, b, c) => c ? b : a;`,
-      errors: 1,
-    },
-    {
-      name: "(c)normal function with brackets around the return statement",
-      code: `function someFunction(a, b, c) { return c ? b : a}`,
       errors: 1,
     },
   ],

--- a/tests/no-ternary-wrappers.spec.js
+++ b/tests/no-ternary-wrappers.spec.js
@@ -61,16 +61,24 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       code: `const result = isRightHanded ? user.rightHand : user.leftHand;`,
     },
 
-    // A function that returns a wrapped ternary but uses global variables,
-    // so it should be valid
+    // Functions that return a wrapped ternary but use externally declared variables,
+    // either partially or completely, so they should be valid
     {
+      name: "valid: completely externally defined symbols ternary",
       code: `
         function chooseHand() {
           return isRightHanded ? globalRightHand : globalLeftHand;
         }
       `,
     },
-
+    {
+      name: "valid: partially externally defined symbols ternary",
+      code: `
+        function chooseHand(localRightHand) {
+          return isRightHanded ? localRightHand : globalLeftHand;
+        }
+      `,
+    },
     // A function that does not return a ternary
     {
       code: `function add(a, b) { return a + b; }`,
@@ -112,7 +120,7 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },
@@ -123,7 +131,7 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },
@@ -138,11 +146,10 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },
-
     // Function with a console log trying to appear meaningful
     {
       code: `
@@ -154,7 +161,7 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },
@@ -170,7 +177,7 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },
@@ -186,7 +193,7 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       errors: [
         {
           message:
-            "Avoid unnecessary function abstractions that simply wrap a ternary expression.",
+            "This is an unnecessary abstraction. Prefer using the ternary expression directly instead of wrapping it in a function.",
         },
       ],
     },

--- a/tests/no-ternary-wrappers.spec.js
+++ b/tests/no-ternary-wrappers.spec.js
@@ -199,5 +199,19 @@ ruleTester.run("no-ternary-wrappers", noUnnecessaryTernaryWrappers, {
       code: `function someFunction(a, b, c) { return a ? b : c}`,
       errors: 1,
     },
+    {
+      name: "Arrow function that returns a sequence expression",
+      code: `const sneaky = (a, b, c)=> (1, a ? b : c);`,
+      errors: 1,
+    },
+    {
+      name: "normal function that returns a squence expression",
+      code: `
+        function sneaky(test, left, right){
+          return 1,test ? left : right;
+        }
+      `,
+      errors: 1,
+    },
   ],
 });


### PR DESCRIPTION
Main changes on this PR:

- Added a small `checkIfLocalParam` util function to cover previously undetected cases
- Added more test cases
- Specified only function/arrow functions as nodes to check on exit,
instead of BlockStatement
  - This is more direct and keeps the checks to a minimum, since from the beginning we're scoping things on each create() to only the scopes we care about idiomatically through AST
  - This fits nicely with the future optional flag to disallow insignificant statements to fool the rule (eg: console logs in the function body, creating a variable first and then returning that, etc.)

Additionally:
- Moved some invalid cases to the valid cases array for now, but hopefully soon we can add a flag to check wether there really are significant operations being done or the user is just trying to circumvent the rule. Sneaky! 🥷 
- Updated the README somewhat
- Bumped up the version to 1.0.0! 🥳 